### PR TITLE
pointcloud: fix memory leak in point cloud destructor

### DIFF
--- a/src/pointcloud.cu
+++ b/src/pointcloud.cu
@@ -313,6 +313,7 @@ void pointcloud::pointCloudToVBOGPU(float *vbodptr_positions, float *vbodptr_rgb
 pointcloud::~pointcloud() {
 	if (isGPU) {
 		cudaFree(dev_pos);
+		cudaFree(dev_matches);
 		cudaFree(dev_rgb);
 	}
 	else {


### PR DESCRIPTION
Hi @botforge, amazing project, thanks for sharing.

Type:
Bugfix: memory leak.

Description:
This PR fixes a memory leak in pointcloud.cu which can result in out-of-memory crashes.
This should solve issue #7.

Solution:
Add a cudaFree(dev_matches) call to the pointcloud destructor to free the memory pointed by dev_matches.

Co-Authored-by: Federico Gavioli <f.gavioli97@gmail.com>
Co-Authored-by: Antonio Russo <270201@studenti.unimore.it>
Signed-off-by: Federico Gavioli <f.gavioli97@gmail.com>